### PR TITLE
op: Amend constructor initializer list order

### DIFF
--- a/src/op.cpp
+++ b/src/op.cpp
@@ -15,7 +15,7 @@
 namespace Sirit {
 
 Op::Op(spv::Op opcode, std::optional<u32> id, Id result_type)
-    : opcode(opcode), id(id), result_type(result_type) {
+    : opcode(opcode), result_type(result_type), id(id) {
     operand_type = OperandType::Op;
 }
 


### PR DESCRIPTION
Amends the order of the initializer list to be structured the same way the members are ordered.

Silences a -Wreorder warning.