### PR TITLE
literal_string: Pass std::string by value where applicable.

### DIFF
--- a/include/sirit/sirit.h
+++ b/include/sirit/sirit.h
@@ -40,7 +40,7 @@ public:
     std::vector<std::uint8_t> Assemble() const;
 
     /// Adds a SPIR-V extension.
-    void AddExtension(const std::string& extension_name);
+    void AddExtension(std::string extension_name);
 
     /// Adds a module capability.
     void AddCapability(spv::Capability capability);
@@ -49,14 +49,14 @@ public:
     void SetMemoryModel(spv::AddressingModel addressing_model, spv::MemoryModel memory_model);
 
     /// Adds an entry point.
-    void AddEntryPoint(spv::ExecutionModel execution_model, Id entry_point, const std::string& name,
+    void AddEntryPoint(spv::ExecutionModel execution_model, Id entry_point, std::string name,
                        const std::vector<Id>& interfaces = {});
 
     /// Adds an entry point.
     template <typename... Ts>
-    void AddEntryPoint(spv::ExecutionModel execution_model, Id entry_point, const std::string& name,
+    void AddEntryPoint(spv::ExecutionModel execution_model, Id entry_point, std::string name,
                        Ts&&... interfaces) {
-        AddEntryPoint(execution_model, entry_point, name, {interfaces...});
+        AddEntryPoint(execution_model, std::move(entry_point), name, {interfaces...});
     }
 
     /// Declare an execution mode for an entry point.
@@ -131,7 +131,7 @@ public:
     }
 
     /// Returns type opaque.
-    Id TypeOpaque(const std::string& name);
+    Id TypeOpaque(std::string name);
 
     /// Returns type pointer.
     Id TypePointer(spv::StorageClass storage_class, Id type);
@@ -224,8 +224,8 @@ public:
     Id OpLabel();
 
     /// The block label instruction: Any reference to a block is through this ref.
-    Id OpLabel(const std::string& label_name) {
-        return Name(OpLabel(), label_name);
+    Id OpLabel(std::string label_name) {
+        return Name(OpLabel(), std::move(label_name));
     }
 
     /// Unconditional jump to label.
@@ -253,14 +253,14 @@ public:
 
     /// Assign a name string to a reference.
     /// @return target
-    Id Name(Id target, const std::string& name);
+    Id Name(Id target, std::string name);
 
     /// Assign a name string to a member of a structure type.
     /// @return type
-    Id MemberName(Id type, std::uint32_t member, const std::string& name);
+    Id MemberName(Id type, std::uint32_t member, std::string name);
 
     /// Assign a Result <id> to a string for use by other debug instructions.
-    Id String(const std::string& string);
+    Id String(std::string string);
 
     /// Add source-level location information
     Id OpLine(Id file, Literal line, Literal column);

--- a/src/instructions/debug.cpp
+++ b/src/instructions/debug.cpp
@@ -11,26 +11,26 @@
 
 namespace Sirit {
 
-Id Module::Name(Id target, const std::string& name) {
+Id Module::Name(Id target, std::string name) {
     auto op{std::make_unique<Op>(spv::Op::OpName)};
     op->Add(target);
-    op->Add(name);
+    op->Add(std::move(name));
     debug.push_back(std::move(op));
     return target;
 }
 
-Id Module::MemberName(Id type, u32 member, const std::string& name) {
+Id Module::MemberName(Id type, u32 member, std::string name) {
     auto op{std::make_unique<Op>(spv::Op::OpMemberName)};
     op->Add(type);
     op->Add(member);
-    op->Add(name);
+    op->Add(std::move(name));
     debug.push_back(std::move(op));
     return type;
 }
 
-Id Module::String(const std::string& string) {
+Id Module::String(std::string string) {
     auto op{std::make_unique<Op>(spv::Op::OpString, bound++)};
-    op->Add(string);
+    op->Add(std::move(string));
     const auto id = op.get();
     debug.push_back(std::move(op));
     return id;

--- a/src/instructions/type.cpp
+++ b/src/instructions/type.cpp
@@ -96,9 +96,9 @@ Id Module::TypeStruct(const std::vector<Id>& members) {
     return AddDeclaration(std::move(op));
 }
 
-Id Module::TypeOpaque(const std::string& name) {
+Id Module::TypeOpaque(std::string name) {
     auto op{std::make_unique<Op>(spv::Op::OpTypeOpaque, bound)};
-    op->Add(name);
+    op->Add(std::move(name));
     return AddDeclaration(std::move(op));
 }
 

--- a/src/literal_string.cpp
+++ b/src/literal_string.cpp
@@ -10,7 +10,7 @@
 
 namespace Sirit {
 
-LiteralString::LiteralString(const std::string& string) : string(string) {
+LiteralString::LiteralString(std::string string) : string{std::move(string)} {
     operand_type = OperandType::String;
 }
 

--- a/src/literal_string.h
+++ b/src/literal_string.h
@@ -14,7 +14,7 @@ namespace Sirit {
 
 class LiteralString : public Operand {
 public:
-    LiteralString(const std::string& string);
+    LiteralString(std::string string);
     ~LiteralString() override;
 
     void Fetch(Stream& stream) const override;

--- a/src/op.cpp
+++ b/src/op.cpp
@@ -110,8 +110,8 @@ void Op::Add(u32 integer) {
     Sink(LiteralNumber::Create<u32>(integer));
 }
 
-void Op::Add(const std::string& string) {
-    Sink(new LiteralString(string));
+void Op::Add(std::string string) {
+    Sink(new LiteralString(std::move(string)));
 }
 
 void Op::Add(const std::vector<Id>& ids) {

--- a/src/op.h
+++ b/src/op.h
@@ -38,7 +38,7 @@ public:
 
     void Add(u32 integer);
 
-    void Add(const std::string& string);
+    void Add(std::string string);
 
     void Add(const std::vector<Id>& ids);
 

--- a/src/sirit.cpp
+++ b/src/sirit.cpp
@@ -66,8 +66,8 @@ std::vector<u8> Module::Assemble() const {
     return bytes;
 }
 
-void Module::AddExtension(const std::string& extension_name) {
-    extensions.insert(extension_name);
+void Module::AddExtension(std::string extension_name) {
+    extensions.insert(std::move(extension_name));
 }
 
 void Module::AddCapability(spv::Capability capability) {
@@ -80,11 +80,11 @@ void Module::SetMemoryModel(spv::AddressingModel addressing_model, spv::MemoryMo
 }
 
 void Module::AddEntryPoint(spv::ExecutionModel execution_model, Id entry_point,
-                           const std::string& name, const std::vector<Id>& interfaces) {
+                           std::string name, const std::vector<Id>& interfaces) {
     auto op{std::make_unique<Op>(spv::Op::OpEntryPoint)};
     op->Add(static_cast<u32>(execution_model));
     op->Add(entry_point);
-    op->Add(name);
+    op->Add(std::move(name));
     op->Add(interfaces);
     entry_points.push_back(std::move(op));
 }


### PR DESCRIPTION
By taking the std::string by value in the constructor, this allows for certain situations where copies can be elided entirely (when moving an instance into the constructor, etc)

e.g.

```cpp
std::string var = ...

...

... = LiteralString(std::move(var)) // Or whatever other initialization
                                    // is done.
```

No copy will be done in this case, the move transfers it into the constructor, and then the move within the initializer list transfers it into the member variable.

tl;dr: This allows calling code to potentially construct less std::string instances by allowing moving into the parameters themselves.