### PR TITLE
op: Use std::vector's insert member function within vector variant of Add

### DIFF
--- a/src/op.cpp
+++ b/src/op.cpp
@@ -115,9 +115,7 @@ void Op::Add(const std::string& string) {
 }
 
 void Op::Add(const std::vector<Id>& ids) {
-    for (Id op : ids) {
-        Add(op);
-    }
+    operands.insert(operands.end(), ids.begin(), ids.end());
 }
 
 u16 Op::WordCount() const {


### PR DESCRIPTION
While looping here does work fine, it's mildly inefficient, particularly if the number of members being added is large, because it can result in multiple allocations over the period of the insertion, depending on how much extra memory push_back may allocate for successive elements.

Instead, we can just tell the std::vector that we want to slap the whole contained sequence at the back of it with insert, which lets it allocate the whole memory block in one attempt.