### PR TITLE
CMakeLists: Apply compilation flags to the sirit target

### DIFF
--- a/include/sirit/sirit.h
+++ b/include/sirit/sirit.h
@@ -46,7 +46,7 @@ public:
     void AddCapability(spv::Capability capability);
 
     /// Sets module memory model.
-    void SetMemoryModel(spv::AddressingModel addressing_model, spv::MemoryModel memory_model);
+    void SetMemoryModel(spv::AddressingModel addressing_model_, spv::MemoryModel memory_model_);
 
     /// Adds an entry point.
     void AddEntryPoint(spv::ExecutionModel execution_model, Id entry_point, std::string name,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,9 @@ add_library(sirit
     instructions/extension.cpp
     instructions/image.cpp
 )
+
+target_compile_options(sirit PRIVATE ${SIRIT_CXX_FLAGS})
+
 target_include_directories(sirit
                            PUBLIC ../include
                            PRIVATE . ${SPIRV-Headers_SOURCE_DIR}/include

--- a/src/op.cpp
+++ b/src/op.cpp
@@ -67,8 +67,8 @@ void Op::Sink(Operand* operand) {
     operand_store.push_back(std::unique_ptr<Operand>(operand));
 }
 
-void Op::Sink(const std::vector<Operand*>& operands) {
-    for (auto* operand : operands) {
+void Op::Sink(const std::vector<Operand*>& operands_) {
+    for (auto* operand : operands_) {
         Sink(operand);
     }
 }

--- a/src/op.h
+++ b/src/op.h
@@ -28,7 +28,7 @@ public:
 
     void Sink(Operand* operand);
 
-    void Sink(const std::vector<Operand*>& operands);
+    void Sink(const std::vector<Operand*>& operands_);
 
     void Add(const Literal& literal);
 

--- a/src/operand.cpp
+++ b/src/operand.cpp
@@ -13,7 +13,7 @@ Operand::Operand() = default;
 
 Operand::~Operand() = default;
 
-void Operand::Fetch(Stream& stream) const {
+void Operand::Fetch([[maybe_unused]] Stream& stream) const {
     assert(!"Fetching unimplemented operand");
 }
 
@@ -22,7 +22,7 @@ u16 Operand::GetWordCount() const {
     return 0;
 }
 
-bool Operand::operator==(const Operand& other) const {
+bool Operand::operator==([[maybe_unused]] const Operand& other) const {
     return false;
 }
 

--- a/src/sirit.cpp
+++ b/src/sirit.cpp
@@ -74,9 +74,9 @@ void Module::AddCapability(spv::Capability capability) {
     capabilities.insert(capability);
 }
 
-void Module::SetMemoryModel(spv::AddressingModel addressing_model, spv::MemoryModel memory_model) {
-    this->addressing_model = addressing_model;
-    this->memory_model = memory_model;
+void Module::SetMemoryModel(spv::AddressingModel addressing_model_, spv::MemoryModel memory_model_) {
+    this->addressing_model = addressing_model_;
+    this->memory_model = memory_model_;
 }
 
 void Module::AddEntryPoint(spv::ExecutionModel execution_model, Id entry_point,


### PR DESCRIPTION
Previously this wasn't utilizing any of the compiler flags, meaning it wasn't applying any of the specified warnings.

Since applying the warnings to the target, this uncovered a few warning cases, such as shadowing class variables on MSVC, etc, which have been fixed.