### PR TITLE
 stream: Change std::string overload for Write to use a std::string_view 

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -13,11 +13,9 @@ Stream::Stream(std::vector<u8>& bytes) : bytes(bytes) {}
 Stream::~Stream() = default;
 
 void Stream::Write(std::string_view string) {
+    bytes.insert(bytes.end(), string.begin(), string.end());
+
     const auto size{string.size()};
-    const auto data{reinterpret_cast<const u8*>(string.data())};
-    for (std::size_t i = 0; i < size; i++) {
-        Write(data[i]);
-    }
     for (std::size_t i = 0; i < 4 - size % 4; i++) {
         Write(static_cast<u8>(0));
     }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -12,9 +12,9 @@ Stream::Stream(std::vector<u8>& bytes) : bytes(bytes) {}
 
 Stream::~Stream() = default;
 
-void Stream::Write(std::string string) {
+void Stream::Write(std::string_view string) {
     const auto size{string.size()};
-    const auto data{reinterpret_cast<u8*>(string.data())};
+    const auto data{reinterpret_cast<const u8*>(string.data())};
     for (std::size_t i = 0; i < size; i++) {
         Write(data[i]);
     }

--- a/src/stream.h
+++ b/src/stream.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <string>
+#include <string_view>
 #include <vector>
 #include "common_types.h"
 
@@ -17,7 +17,7 @@ public:
     explicit Stream(std::vector<u8>& bytes);
     ~Stream();
 
-    void Write(std::string string);
+    void Write(std::string_view string);
 
     void Write(u64 value);
 


### PR DESCRIPTION
Allows various string types to be used with the overload without constructing a std::string (such as const char* etc).

We can also insert the string itself in one operation like the other overloads do with their data. We only need to do byte-by-byte appending when padding occurs.