### PR TITLE
common_types: Include types within the Sirit namespace

### DIFF
--- a/src/common_types.h
+++ b/src/common_types.h
@@ -9,6 +9,8 @@
 #include <cstddef>
 #include <cstdint>
 
+namespace Sirit {
+
 using u8 = std::uint8_t;
 using u16 = std::uint16_t;
 using u32 = std::uint32_t;
@@ -25,3 +27,5 @@ using f32 = float;
 using f64 = double;
 static_assert(sizeof(f32) == sizeof(u32), "f32 must be 32 bits wide");
 static_assert(sizeof(f64) == sizeof(u64), "f64 must be 64 bits wide");
+
+} // namespace Sirit


### PR DESCRIPTION
Avoids dumping types into global scope.