### PR TITLE
sirit: Remove unnecessary std::move in OpLabel

### DIFF
--- a/include/sirit/sirit.h
+++ b/include/sirit/sirit.h
@@ -275,7 +275,7 @@ public:
 
     /// The block label instruction: Any reference to a block is through this ref.
     Id OpLabel(std::string_view label_name) {
-        return Name(OpLabel(), std::move(label_name));
+        return Name(OpLabel(), label_name);
     }
 
     /// Unconditional jump to label.


### PR DESCRIPTION
std::move on a std::string_view doesn't do anything a regular copy wouldn't.