### PR TITLE
sirit: Add TypeSInt/TypeUInt helpers

### DIFF
--- a/include/sirit/sirit.h
+++ b/include/sirit/sirit.h
@@ -125,6 +125,12 @@ public:
     /// Returns type integer.
     Id TypeInt(int width, bool is_signed);
 
+    /// Returns type signed integer.
+    Id TypeSInt(int width);
+
+    /// Returns type unsigned integer.
+    Id TypeUInt(int width);
+
     /// Returns type float.
     Id TypeFloat(int width);
 

--- a/src/instructions/type.cpp
+++ b/src/instructions/type.cpp
@@ -28,6 +28,14 @@ Id Module::TypeInt(int width, bool is_signed) {
     return *declarations << OpId{spv::Op::OpTypeInt} << width << is_signed << EndOp{};
 }
 
+Id Module::TypeSInt(int width) {
+    return TypeInt(width, true);
+}
+
+Id Module::TypeUInt(int width) {
+    return TypeInt(width, false);
+}
+
 Id Module::TypeFloat(int width) {
     declarations->Reserve(3);
     return *declarations << OpId{spv::Op::OpTypeFloat} << width << EndOp{};


### PR DESCRIPTION
Provides shorthands for specific signedness, so that usage code doesn't need to explicitly use raw booleans in most cases.

`TypeUInt(32)`, is slightly more convenient to gloss than `TypeInt(32, false)`, especially for those not familiar with the API.