### PR TITLE
cmake: Add option to unbundle SPIRV-Headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(MASTER_PROJECT ON)
 endif()
 
+# Sirit project options
+option(SIRIT_TESTS "Build tests" OFF)
+option(SIRIT_USE_SYSTEM_SPIRV_HEADERS "Use system SPIR-V headers" OFF)
+
 # Default to a Release build
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
@@ -81,7 +85,12 @@ endif()
 enable_testing(true)
 
 # SPIR-V headers
-add_subdirectory(externals/SPIRV-Headers EXCLUDE_FROM_ALL)
+if (SIRIT_USE_SYSTEM_SPIRV_HEADERS)
+    find_package(SPIRV-Headers REQUIRED)
+else()
+    add_subdirectory(externals/SPIRV-Headers EXCLUDE_FROM_ALL)
+    add_library(SPIRV-Headers::SPIRV-Headers ALIAS SPIRV-Headers)
+endif()
 
 # Sirit project files
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,5 +27,6 @@ target_compile_options(sirit PRIVATE ${SIRIT_CXX_FLAGS})
 
 target_include_directories(sirit
                            PUBLIC ../include
-                           PRIVATE . ${SPIRV-Headers_SOURCE_DIR}/include
-                           INTERFACE ${SPIRV-Headers_SOURCE_DIR}/include)
+                           PRIVATE .)
+
+target_link_libraries(sirit PUBLIC SPIRV-Headers::SPIRV-Headers)


### PR DESCRIPTION
Also add an option for the `SIRIT_TESTS` variable ;)