### PR TITLE
Include <utility> header for gcc 12

### DIFF
--- a/src/stream.h
+++ b/src/stream.h
@@ -15,6 +15,7 @@
 #include <unordered_map>
 #include <variant>
 #include <vector>
+#include <utility>
 
 #ifndef __cpp_lib_bit_cast
 #include <cstring>


### PR DESCRIPTION
Currently `std::exchange` fails to be detected thus making the build fail, including the header fixes it.
