### PR TITLE
Add missing glsl extension instructions

### DIFF
--- a/include/sirit/sirit.h
+++ b/include/sirit/sirit.h
@@ -256,6 +256,12 @@ public:
      */
     Id OpPhi(Id result_type, std::span<const Id> operands);
 
+    template <typename... Ts>
+    requires(...&& std::is_convertible_v<Ts, Id>) Id
+        OpPhi(Id result_type, Ts&&... operands) {
+        return OpPhi(result_type, std::span<const Id>({operands...}));
+    }
+    
     /**
      * The SSA phi function. This instruction will be revisited when patching phi nodes.
      *

--- a/include/sirit/sirit.h
+++ b/include/sirit/sirit.h
@@ -361,6 +361,17 @@ public:
     /// Make a copy of a vector, with a single, variably selected, component modified.
     Id OpVectorInsertDynamic(Id result_type, Id vector, Id component, Id index);
 
+    /// Select arbitrary components from two vectors to make a new vector.
+    Id OpVectorShuffle(Id result_type, Id vector_1, Id vector_2, std::span<const Literal> components);
+
+    /// Select arbitrary components from two vectors to make a new vector.
+    template <typename... Ts>
+    requires(...&& std::is_convertible_v<Ts, Literal>) Id
+        OpVectorShuffle(Id result_type, Id vector_1, Id vector_2, Ts&&... components) {
+        const Literal stack_literals[] = {std::forward<Ts>(components)...};
+        return OpVectorShuffle(result_type, vector_1, vector_2, std::span<const Literal>{stack_literals});
+    }
+
     /// Make a copy of a composite object, while modifying one part of it.
     Id OpCompositeInsert(Id result_type, Id object, Id composite,
                          std::span<const Literal> indexes = {});
@@ -682,6 +693,12 @@ public:
     /// Result is the unsigned integer addition of Operand 1 and Operand 2, including its carry.
     Id OpIAddCarry(Id result_type, Id operand_1, Id operand_2);
 
+    /// Multiplication of floating-point vector Operand 1 with scalar Operand 2.
+    Id OpVectorTimesScalar(Id result_type, Id operand_1, Id operand_2);
+
+    /// Dot product of floating-point vector Operand 1 and vector Operand 2.
+    Id OpDot(Id result_type, Id operand_1, Id operand_2);
+
     // Extensions
 
     /// Execute an instruction in an imported set of extended instructions.
@@ -832,6 +849,18 @@ public:
     /// Result is the value of the input interpolant variable sampled at an offset from the center
     /// of the pixel specified by offset.
     Id OpInterpolateAtOffset(Id result_type, Id interpolant, Id offset);
+
+    /// Result is the vector in the same direction as x but with a length of 1.
+    Id OpNormalize(Id result_type, Id x);
+
+    /// Result is the cross product of x and y.
+    Id OpCross(Id result_type, Id x, Id y);
+
+    /// Result is the length of vector x.
+    Id OpLength(Id result_type, Id x);
+
+    /// Result is the linear blend of x and y i.e x * (1 - a) + y * a
+    Id OpFMix(Id result_type, Id x, Id y, Id a);
 
     // Derivatives
 

--- a/src/instructions/arithmetic.cpp
+++ b/src/instructions/arithmetic.cpp
@@ -40,5 +40,7 @@ DEFINE_BINARY(OpFMod, spv::Op::OpFMod)
 DEFINE_BINARY(OpSRem, spv::Op::OpSRem)
 DEFINE_BINARY(OpFRem, spv::Op::OpFRem)
 DEFINE_BINARY(OpIAddCarry, spv::Op::OpIAddCarry)
+DEFINE_BINARY(OpVectorTimesScalar, spv::Op::OpVectorTimesScalar)
+DEFINE_BINARY(OpDot, spv::Op::OpDot)
 
 } // namespace Sirit

--- a/src/instructions/extension.cpp
+++ b/src/instructions/extension.cpp
@@ -72,5 +72,9 @@ DEFINE_UNARY(OpFindUMsb, GLSLstd450FindUMsb)
 DEFINE_UNARY(OpInterpolateAtCentroid, GLSLstd450InterpolateAtCentroid)
 DEFINE_BINARY(OpInterpolateAtSample, GLSLstd450InterpolateAtSample)
 DEFINE_BINARY(OpInterpolateAtOffset, GLSLstd450InterpolateAtOffset)
+DEFINE_UNARY(OpNormalize, GLSLstd450Normalize)
+DEFINE_BINARY(OpCross, GLSLstd450Cross)
+DEFINE_UNARY(OpLength, GLSLstd450Length);
+DEFINE_TRINARY(OpFMix, GLSLstd450FMix)
 
 } // namespace Sirit

--- a/src/instructions/memory.cpp
+++ b/src/instructions/memory.cpp
@@ -46,6 +46,12 @@ Id Module::OpVectorInsertDynamic(Id result_type, Id vector, Id component, Id ind
                  << index << EndOp{};
 }
 
+Id Module::OpVectorShuffle(Id result_type, Id vector_1, Id vector_2, std::span<const Literal> components) {
+    code->Reserve(5 + components.size());
+    return *code << OpId{spv::Op::OpVectorShuffle, result_type} << vector_1 << vector_2
+                 << components << EndOp{};
+}
+
 Id Module::OpCompositeInsert(Id result_type, Id object, Id composite,
                              std::span<const Literal> indexes) {
     code->Reserve(5 + indexes.size());

--- a/src/stream.h
+++ b/src/stream.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <bit>
+#include <span>
 #include <cassert>
 #include <concepts>
 #include <cstddef>

--- a/src/stream.h
+++ b/src/stream.h
@@ -63,7 +63,7 @@ inline void InsertStringView(std::vector<u32>& words, size_t& insert_index,
 
 class Stream {
     friend Declarations;
-
+    static constexpr std::size_t GROW_STEP = 1024;
 public:
     explicit Stream(u32* bound_) : bound{bound_} {}
 
@@ -71,7 +71,7 @@ public:
         if (insert_index + num_words <= words.size()) {
             return;
         }
-        words.resize(insert_index + num_words);
+        words.resize(insert_index + GROW_STEP);
     }
 
     std::span<const u32> Words() const noexcept {


### PR DESCRIPTION
* These were required to implement a spirv emitter for citra's shader generator
* In addition I've included some other small fixes I found useful