### PR TITLE
Add OpDemoteToHelperInvocation, OpTerminateInvocation

### DIFF
--- a/include/sirit/sirit.h
+++ b/include/sirit/sirit.h
@@ -309,11 +309,15 @@ public:
     /// Return a value from a function.
     Id OpReturnValue(Id value);
 
-    /// Fragment-shader discard.
+    /// Deprecated fragment-shader discard.
     void OpKill();
 
     /// Demote fragment shader invocation to a helper invocation
+    void OpDemoteToHelperInvocation();
     void OpDemoteToHelperInvocationEXT();
+
+    /// Fragment-shader discard.
+    void OpTerminateInvocation();
 
     // Debug
 

--- a/src/instructions/flow.cpp
+++ b/src/instructions/flow.cpp
@@ -92,9 +92,18 @@ void Module::OpKill() {
     *code << spv::Op::OpKill << EndOp{};
 }
 
-void Module::OpDemoteToHelperInvocationEXT() {
+void Module::OpDemoteToHelperInvocation() {
     code->Reserve(1);
-    *code << spv::Op::OpDemoteToHelperInvocationEXT << EndOp{};
+    *code << spv::Op::OpDemoteToHelperInvocation << EndOp{};
+}
+
+void Module::OpDemoteToHelperInvocationEXT() {
+    OpDemoteToHelperInvocation();
+}
+
+void Module::OpTerminateInvocation() {
+    code->Reserve(1);
+    *code << spv::Op::OpTerminateInvocation << EndOp{};
 }
 
 } // namespace Sirit


### PR DESCRIPTION
OpDemoteToHelperInvocationEXT deprecated, now alias of OpDemoteToHelperInvocation
OpKill deprecated, now recommended to use OpTerminateInvocation

Also updates SPIRV-Headers to latest for CapabilityDemoteToHelperInvocation